### PR TITLE
Add Texpacker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ emulator
 build
 .vscode
 docs/html
+*.swp

--- a/tools/build.cmd
+++ b/tools/build.cmd
@@ -3,3 +3,4 @@ go build -o bin/bento.exe ./bento
 go build -o bin/gcpacker.exe ./gcpacker
 go build -o bin/texconv.exe ./texconv
 go build -o bin/tevasm.exe ./tevasm
+go build -o bin/texpacker.exe ./texpacker

--- a/tools/build.cmd
+++ b/tools/build.cmd
@@ -1,3 +1,5 @@
+go get github.com/adinfinit/texpack/maxrect
+
 go build -o bin/objconv.exe ./objconv
 go build -o bin/bento.exe ./bento
 go build -o bin/gcpacker.exe ./gcpacker

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -3,3 +3,4 @@ go build -o bin/bento ./bento
 go build -o bin/gcpacker ./gcpacker
 go build -o bin/texconv ./texconv
 go build -o bin/tevasm ./tevasm
+go build -o bin/texpacker ./texpacker

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,3 +1,5 @@
+go get github.com/adinfinit/texpack/maxrect
+
 go build -o bin/objconv ./objconv
 go build -o bin/bento ./bento
 go build -o bin/gcpacker ./gcpacker

--- a/tools/texpacker/format.go
+++ b/tools/texpacker/format.go
@@ -43,16 +43,16 @@ func ToFileHash(s string) FileHash {
 
 func (f FileHash) Bytes() []byte {
 	out := make([]byte, 4)
-	binary.BigEndian.PutUint32(out, uint32(f))
+	binary.BigEndian.PutUint32(out[0:], uint32(f))
 	return out
 }
 
 func (e Entry) Bytes() []byte {
 	out := make([]byte, 12)
-	binary.BigEndian.PutUint32(out, uint32(e.TexPath))
-	binary.BigEndian.PutUint16(out, e.Coords.Start.X)
-	binary.BigEndian.PutUint16(out, e.Coords.Start.Y)
-	binary.BigEndian.PutUint16(out, e.Coords.Size.X)
-	binary.BigEndian.PutUint16(out, e.Coords.Size.Y)
+	binary.BigEndian.PutUint32(out[0:], uint32(e.TexPath))
+	binary.BigEndian.PutUint16(out[4:], e.Coords.Start.X)
+	binary.BigEndian.PutUint16(out[6:], e.Coords.Start.Y)
+	binary.BigEndian.PutUint16(out[8:], e.Coords.Size.X)
+	binary.BigEndian.PutUint16(out[10:], e.Coords.Size.Y)
 	return out
 }

--- a/tools/texpacker/format.go
+++ b/tools/texpacker/format.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+)
+
+// 4 bytes
+type Point struct {
+	X, Y uint16
+}
+
+// 8 bytes
+type Rect struct {
+	Start, Size Point
+}
+
+type FileHash uint32
+
+// 4 + 4 = 8 bytes
+type Header struct {
+	ParentTexture FileHash
+	EntryCount    int
+}
+
+// An Entry is a single texture's path + coordinates. 4 + 8 = 12 bytes
+type Entry struct {
+	TexPath FileHash
+	Coords  Rect
+}
+
+var hash = fnv.New32()
+
+func ToFileHash(s string) FileHash {
+	hash.Reset()
+	_, err := fmt.Fprintf(hash, s)
+	if err != nil {
+		panic(err)
+	}
+	return FileHash(hash.Sum32())
+}
+
+func (f FileHash) Bytes() []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, uint32(f))
+	return out
+}
+
+func (e Entry) Bytes() []byte {
+	out := make([]byte, 12)
+	binary.BigEndian.PutUint32(out, uint32(e.TexPath))
+	binary.BigEndian.PutUint16(out, e.Coords.Start.X)
+	binary.BigEndian.PutUint16(out, e.Coords.Start.Y)
+	binary.BigEndian.PutUint16(out, e.Coords.Size.X)
+	binary.BigEndian.PutUint16(out, e.Coords.Size.Y)
+	return out
+}

--- a/tools/texpacker/format.go
+++ b/tools/texpacker/format.go
@@ -7,13 +7,13 @@ import (
 )
 
 // 4 bytes
-type Point struct {
+type Vector2 struct {
 	X, Y uint16
 }
 
 // 8 bytes
 type Rect struct {
-	Start, Size Point
+	Start, Size Vector2
 }
 
 type FileHash uint32
@@ -35,9 +35,7 @@ var hash = fnv.New32()
 func ToFileHash(s string) FileHash {
 	hash.Reset()
 	_, err := fmt.Fprintf(hash, s)
-	if err != nil {
-		panic(err)
-	}
+	checkErr(err, "Failed to hash string %s", s)
 	return FileHash(hash.Sum32())
 }
 

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -23,8 +23,7 @@ func main() {
 		}
 	}
 	outpath := flag.String("o", "out.png", "Output file")
-	maxW := flag.Int("maxwidth", 1<<16, "Max width of output texture in pixels")
-	maxH := flag.Int("maxheight", 1<<16, "Max height of output texture in pixels")
+	maxSize := flag.Int("maxsize", 1<<16, "Max size (width/height) of output texture in pixels")
 	cwd, err := os.Getwd()
 	checkErr(err, "Couldn't get working directory")
 	stripPfx := flag.String("prefix", cwd, "Prefix to strip from file paths for hashing")
@@ -38,7 +37,7 @@ func main() {
 	// All positional arguments are input files
 	inputFiles := flag.Args()
 
-	maxBounds := image.Point{*maxW, *maxH}
+	maxBounds := image.Point{*maxSize, *maxSize}
 	absoutpath, err := filepath.Abs(*outpath)
 	checkErr(err, "Error converting outpath %s to absolute", *outpath)
 	packer := NewTexPacker(absoutpath, TexPackerOptions{

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"image"
 	"os"
 
 	// Image formats
@@ -21,6 +22,7 @@ func main() {
 		}
 	}
 	outpath := flag.String("o", "-", "Output file (- for STDOUT)")
+	noheader := flag.Bool("nohead", false, "Don't add header, output atlas as a raw PNG image")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
@@ -40,7 +42,8 @@ func main() {
 		out = file
 	}
 
-	packer := NewTexPacker()
+	maxBounds := image.Point{2048, 2048} // TODO
+	packer := NewTexPacker(maxBounds)
 	// Read images from input
 	for _, path := range inputFiles {
 		in, err := os.Open(path)
@@ -48,7 +51,9 @@ func main() {
 		defer in.Close()
 		packer.Add(in)
 	}
-	packer.Save(out)
+	if err := packer.Save(out); err != nil {
+		panic(err)
+	}
 }
 
 func checkErr(err error, msg string, args ...interface{}) {

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [-o outfile] <file1> [<file2> ...]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [flags] <file1> [<file2> ...]\n", os.Args[0])
 		flag.PrintDefaults()
 		fmt.Fprint(os.Stderr, "\nSupported input formats:\n")
 		for _, format := range []string{"JPEG", "GIF", "PNG"} {

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -22,6 +22,7 @@ func main() {
 		}
 	}
 	outpath := flag.String("o", "-", "Output file (- for STDOUT)")
+	noheader := flag.Bool("noheader", false, "Don't write header, output raw PNG")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
@@ -34,7 +35,8 @@ func main() {
 
 	maxBounds := image.Point{1 << 16, 1 << 16} // TODO
 	packer := NewTexPacker(*outpath, TexPackerOptions{
-		MaxBounds: maxBounds,
+		MaxBounds:   maxBounds,
+		WriteHeader: !*noheader,
 	})
 	// Read images from input
 	for _, path := range inputFiles {

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -24,9 +24,11 @@ func main() {
 	}
 	outpath := flag.String("o", "-", "Output file (- for STDOUT)")
 	noheader := flag.Bool("noheader", false, "Don't write header, output raw PNG")
+	maxW := flag.Int("maxwidth", 1<<16, "Max width of output texture")
+	maxH := flag.Int("maxheight", 1<<16, "Max height of output texture")
 	cwd, err := os.Getwd()
 	checkErr(err, "Couldn't get working directory")
-	stripPfx := flag.String("strip", cwd, "Prefix to strip from file paths for hashing")
+	stripPfx := flag.String("prefix", cwd, "Prefix to strip from file paths for hashing")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
@@ -37,7 +39,7 @@ func main() {
 	// All positional arguments are input files
 	inputFiles := flag.Args()
 
-	maxBounds := image.Point{1 << 16, 1 << 16} // TODO
+	maxBounds := image.Point{*maxW, *maxH}
 	absoutpath, err := filepath.Abs(*outpath)
 	checkErr(err, "Error converting outpath %s to absolute", *outpath)
 	packer := NewTexPacker(absoutpath, TexPackerOptions{
@@ -52,9 +54,7 @@ func main() {
 		checkErr(err, "Error converting file path %s to absolute", path)
 		packer.Add(abspath)
 	}
-	if err := packer.Save(); err != nil {
-		panic(err)
-	}
+	checkErr(packer.Save(), "Failed to save packed texture")
 }
 
 func checkErr(err error, msg string, args ...interface{}) {

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -22,10 +22,9 @@ func main() {
 			fmt.Fprintf(os.Stderr, "    %s\n", format)
 		}
 	}
-	outpath := flag.String("o", "-", "Output file (- for STDOUT)")
-	noheader := flag.Bool("noheader", false, "Don't write header, output raw PNG")
-	maxW := flag.Int("maxwidth", 1<<16, "Max width of output texture")
-	maxH := flag.Int("maxheight", 1<<16, "Max height of output texture")
+	outpath := flag.String("o", "out.png", "Output file")
+	maxW := flag.Int("maxwidth", 1<<16, "Max width of output texture in pixels")
+	maxH := flag.Int("maxheight", 1<<16, "Max height of output texture in pixels")
 	cwd, err := os.Getwd()
 	checkErr(err, "Couldn't get working directory")
 	stripPfx := flag.String("prefix", cwd, "Prefix to strip from file paths for hashing")
@@ -44,7 +43,6 @@ func main() {
 	checkErr(err, "Error converting outpath %s to absolute", *outpath)
 	packer := NewTexPacker(absoutpath, TexPackerOptions{
 		MaxBounds:   maxBounds,
-		WriteHeader: !*noheader,
 		StripPrefix: *stripPfx,
 	})
 	// Read images from input

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	// Image formats
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [-o outfile] <file1> [<file2> ...]\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprint(os.Stderr, "\nSupported input formats:\n")
+		for _, format := range []string{"JPEG", "GIF", "PNG"} {
+			fmt.Fprintf(os.Stderr, "    %s\n", format)
+		}
+	}
+	outpath := flag.String("o", "-", "Output file (- for STDOUT)")
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "[FAIL] No input files were specified\n")
+		os.Exit(1)
+	}
+
+	// All positional arguments are input files
+	inputFiles := flag.Args()
+
+	// Get output writer
+	out := os.Stdout
+	if *outpath != "-" {
+		file, err := os.Create(*outpath)
+		checkErr(err, "Cannot create output file")
+		defer file.Close()
+		out = file
+	}
+
+	packer := NewTexPacker()
+	// Read images from input
+	for _, path := range inputFiles {
+		in, err := os.Open(path)
+		checkErr(err, "Cannot open input file: "+path)
+		defer in.Close()
+		packer.Add(in)
+	}
+	packer.Save(out)
+}
+
+func checkErr(err error, msg string, args ...interface{}) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[FAIL] "+msg+":\n    ", args...)
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -38,7 +38,9 @@ func main() {
 	inputFiles := flag.Args()
 
 	maxBounds := image.Point{1 << 16, 1 << 16} // TODO
-	packer := NewTexPacker(*outpath, TexPackerOptions{
+	absoutpath, err := filepath.Abs(*outpath)
+	checkErr(err, "Error converting outpath %s to absolute", *outpath)
+	packer := NewTexPacker(absoutpath, TexPackerOptions{
 		MaxBounds:   maxBounds,
 		WriteHeader: !*noheader,
 		StripPrefix: *stripPfx,

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -22,7 +22,6 @@ func main() {
 		}
 	}
 	outpath := flag.String("o", "-", "Output file (- for STDOUT)")
-	noheader := flag.Bool("nohead", false, "Don't add header, output atlas as a raw PNG image")
 	flag.Parse()
 
 	if flag.NArg() < 1 {

--- a/tools/texpacker/main.go
+++ b/tools/texpacker/main.go
@@ -32,25 +32,15 @@ func main() {
 	// All positional arguments are input files
 	inputFiles := flag.Args()
 
-	// Get output writer
-	out := os.Stdout
-	if *outpath != "-" {
-		file, err := os.Create(*outpath)
-		checkErr(err, "Cannot create output file")
-		defer file.Close()
-		out = file
-	}
-
-	maxBounds := image.Point{2048, 2048} // TODO
-	packer := NewTexPacker(maxBounds)
+	maxBounds := image.Point{1 << 16, 1 << 16} // TODO
+	packer := NewTexPacker(*outpath, TexPackerOptions{
+		MaxBounds: maxBounds,
+	})
 	// Read images from input
 	for _, path := range inputFiles {
-		in, err := os.Open(path)
-		checkErr(err, "Cannot open input file: "+path)
-		defer in.Close()
-		packer.Add(in)
+		packer.Add(path)
 	}
-	if err := packer.Save(out); err != nil {
+	if err := packer.Save(); err != nil {
 		panic(err)
 	}
 }

--- a/tools/texpacker/packer.go
+++ b/tools/texpacker/packer.go
@@ -139,8 +139,10 @@ func (packer *TexPacker) writeHeader(output io.Writer) error {
 	hashes := make(map[FileHash]string, nEntries)
 
 	// Parent Texture Hash
-	ptHash := ToFileHash(packer.outfile)
-	hashes[ptHash] = packer.outfile
+	relpath, err := filepath.Rel(packer.options.StripPrefix, packer.outfile)
+	checkErr(err, "Error converting absolute path %s to relative (with base %s)", packer.outfile, packer.options.StripPrefix)
+	ptHash := ToFileHash(relpath)
+	hashes[ptHash] = relpath
 	if _, err := output.Write(ptHash.Bytes()); err != nil {
 		return err
 	}

--- a/tools/texpacker/packer.go
+++ b/tools/texpacker/packer.go
@@ -13,7 +13,8 @@ import (
 )
 
 type TexPackerOptions struct {
-	MaxBounds image.Point
+	MaxBounds   image.Point
+	WriteHeader bool
 }
 
 type TexPacker struct {
@@ -67,8 +68,10 @@ func (packer *TexPacker) Save() error {
 	if err != nil {
 		return err
 	}
-	if err = packer.writeHeader(output); err != nil {
-		return err
+	if packer.options.WriteHeader {
+		if err = packer.writeHeader(output); err != nil {
+			return err
+		}
 	}
 	return png.Encode(output, outtex)
 }

--- a/tools/texpacker/packer.go
+++ b/tools/texpacker/packer.go
@@ -8,6 +8,7 @@ import (
 	"image/png"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/adinfinit/texpack/maxrect"
 )
@@ -15,6 +16,7 @@ import (
 type TexPackerOptions struct {
 	MaxBounds   image.Point
 	WriteHeader bool
+	StripPrefix string
 }
 
 type TexPacker struct {
@@ -49,9 +51,12 @@ func (packer *TexPacker) Add(texpath string) error {
 	if fmt != "png" && fmt != "jpeg" && fmt != "gif" {
 		return errors.New("Unsupported input format: " + fmt)
 	}
+	// Strip path prefix
+	relpath, err := filepath.Rel(packer.options.StripPrefix, texpath)
+	checkErr(err, "Error converting absolute path %s to relative (with base %s)", texpath, packer.options.StripPrefix)
 	packer.images = append(packer.images, imageInfo{
 		Image: img,
-		Path:  texpath,
+		Path:  relpath,
 	})
 	return nil
 }

--- a/tools/texpacker/packer.go
+++ b/tools/texpacker/packer.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"errors"
+	"image"
+	"image/png"
+	"io"
+)
+
+type TexPacker struct {
+	images []image.Image // List of textures to pack
+}
+
+func NewTexPacker() *TexPacker {
+	return &TexPacker{}
+}
+
+// Add specifies a new texture to be packed.
+func (packer *TexPacker) Add(input io.Reader) error {
+	img, fmt, err := image.Decode(input)
+	if err != nil {
+		return err
+	}
+	if fmt != "png" && fmt != "jpeg" && fmt != "gif" {
+		return errors.New("Unsupported input format: " + fmt)
+	}
+	packer.images = append(packer.images, img)
+	return nil
+}
+
+// Save packs all the given textures into one and writes the result into `output`
+func (packer *TexPacker) Save(output io.Writer) error {
+	outtex, err := packer.pack()
+	if err != nil {
+		return err
+	}
+	return png.Encode(output, outtex)
+}
+
+func (packer *TexPacker) pack() (image.Image, error) {
+	// Calculate output bounds (TODO)
+	outbounds := packer.calcOutBounds()
+
+	// Write packed texture
+	outtex := image.NewRGBA(outbounds)
+	var x, y int
+	for _, img := range packer.images {
+		if err := addImageAt(outtex, img, x, y); err != nil {
+			return nil, err
+		}
+		y += img.Bounds().Size().Y
+	}
+	return outtex, nil
+}
+
+func (packer *TexPacker) calcOutBounds() image.Rectangle {
+	var w, h int
+	for _, img := range packer.images {
+		sz := img.Bounds().Size()
+		if sz.X > w {
+			w = sz.X
+		}
+		h += sz.Y
+	}
+	return image.Rect(0, 0, w, h)
+}
+
+// addImageAt adds all pixels of `src` to `dst`, starting from pixel at (`x`,`y`).
+// It returns an error if the whole source image couldn't be added to the target.
+func addImageAt(dst *image.RGBA, src image.Image, x, y int) error {
+	srcsize := src.Bounds().Size()
+	dstsize := dst.Bounds().Size()
+	if srcsize.X > dstsize.X-x || srcsize.Y > dstsize.Y-y {
+		return errors.New("The given image couldn't fit into the destination image")
+	}
+
+	for py := y; py < y+srcsize.Y; py++ {
+		for px := x; px < x+srcsize.X; px++ {
+			dst.Set(px, py, src.At(px-x, py-y))
+		}
+	}
+
+	return nil
+}

--- a/tools/texpacker/packer.go
+++ b/tools/texpacker/packer.go
@@ -88,6 +88,10 @@ func (packer *TexPacker) getOutputs() (imageOut io.WriteCloser, headerOut io.Wri
 		return
 	}
 	headerOut, err = os.Create(packer.outfile + ".atlas")
+	if err != nil {
+		imageOut.Close()
+		return
+	}
 	return
 }
 

--- a/tools/texpacker/packer.go
+++ b/tools/texpacker/packer.go
@@ -1,27 +1,46 @@
 package main
 
 import (
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"image"
 	"image/png"
 	"io"
+	"os"
 
 	"github.com/adinfinit/texpack/maxrect"
 )
 
-type TexPacker struct {
-	maxBounds image.Point
-	images    []image.Image // List of textures to pack
+type TexPackerOptions struct {
+	MaxBounds image.Point
 }
 
-func NewTexPacker(maxBounds image.Point) *TexPacker {
+type TexPacker struct {
+	outfile string
+	options TexPackerOptions
+	images  []imageInfo
+}
+
+type imageInfo struct {
+	Image  image.Image
+	Path   string
+	Coords Rect
+}
+
+func NewTexPacker(outfile string, options TexPackerOptions) *TexPacker {
 	return &TexPacker{
-		maxBounds: maxBounds,
+		outfile: outfile,
+		options: options,
 	}
 }
 
 // Add specifies a new texture to be packed.
-func (packer *TexPacker) Add(input io.Reader) error {
+func (packer *TexPacker) Add(texpath string) error {
+	input, err := os.Open(texpath)
+	checkErr(err, "Cannot open input file: "+texpath)
+	defer input.Close()
+
 	img, fmt, err := image.Decode(input)
 	if err != nil {
 		return err
@@ -29,57 +48,132 @@ func (packer *TexPacker) Add(input io.Reader) error {
 	if fmt != "png" && fmt != "jpeg" && fmt != "gif" {
 		return errors.New("Unsupported input format: " + fmt)
 	}
-	packer.images = append(packer.images, img)
+	packer.images = append(packer.images, imageInfo{
+		Image: img,
+		Path:  texpath,
+	})
 	return nil
 }
 
 // Save packs all the given textures into one and writes the result into `output`
-func (packer *TexPacker) Save(output io.Writer) error {
+func (packer *TexPacker) Save() error {
+	output, err := packer.getOutput()
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
 	outtex, err := packer.pack()
 	if err != nil {
+		return err
+	}
+	if err = packer.writeHeader(output); err != nil {
 		return err
 	}
 	return png.Encode(output, outtex)
 }
 
-func (packer *TexPacker) pack() (image.Image, error) {
-	// Calculate output bounds (TODO)
-
-	points := make([]image.Point, len(packer.images))
-	for i, img := range packer.images {
-		points[i] = img.Bounds().Size()
+// getOutput opens the output file and returns its handle
+func (packer *TexPacker) getOutput() (io.WriteCloser, error) {
+	// Get output writer
+	out := os.Stdout
+	if packer.outfile != "-" {
+		file, err := os.Create(packer.outfile)
+		if err != nil {
+			return nil, errors.New("Cannot create output file")
+		}
+		out = file
 	}
-	outsize, positions, ok := minimizeFit(packer.maxBounds, points)
+	return out, nil
+}
+
+// pack runs the maxrect algorithms on the input textures, then writes the result
+// in the output texture, which is returned
+func (packer *TexPacker) pack() (image.Image, error) {
+
+	points := getImageSizes(packer.images)
+
+	outsize, positions, ok := minimizeFit(packer.options.MaxBounds, points)
 	if !ok {
 		return nil, errors.New("Couldn't pack all images!")
 	}
 
 	// Write packed texture
 	outtex := image.NewRGBA(image.Rect(0, 0, outsize.X, outsize.Y))
-	for i, img := range packer.images {
+	for i, imginfo := range packer.images {
 		pos := positions[i]
-		if err := addImageAt(outtex, img, pos.Min.X, pos.Min.Y); err != nil {
+		if err := writeImageAt(outtex, imginfo.Image, pos.Min.X, pos.Min.Y); err != nil {
 			return nil, err
 		}
+		packer.images[i].Coords = Rect{
+			Start: Point{uint16(pos.Min.X), uint16(pos.Min.Y)},
+			Size:  Point{uint16(pos.Dx()), uint16(pos.Dy())},
+		}
+		// No need to keep this anymore
+		packer.images[i].Image = nil
 	}
+
 	return outtex, nil
 }
 
-func (packer *TexPacker) calcOutBounds() image.Rectangle {
-	var w, h int
-	for _, img := range packer.images {
-		sz := img.Bounds().Size()
-		if sz.X > w {
-			w = sz.X
-		}
-		h += sz.Y
+// writeHeader outputs binary metadata on the packed textures to the given Writer.
+func (packer *TexPacker) writeHeader(output io.Writer) error {
+
+	nEntries := len(packer.images)
+
+	// Output file format is:
+	// ParentTexture Hash [4B]
+	// Entry Count        [4B]
+	// Entry0             [12B]
+	// ...
+
+	// Used to check hash collisions
+	hashes := make(map[FileHash]string, nEntries)
+
+	// Parent Texture Hash
+	ptHash := ToFileHash(packer.outfile)
+	hashes[ptHash] = packer.outfile
+	if _, err := output.Write(ptHash.Bytes()); err != nil {
+		return err
 	}
-	return image.Rect(0, 0, w, h)
+
+	// Entry Count
+	countbuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(countbuf, uint32(nEntries))
+	if _, err := output.Write(countbuf); err != nil {
+		return err
+	}
+
+	// Entries
+	for _, imginfo := range packer.images {
+		hash := ToFileHash(imginfo.Path)
+		if orig, collides := hashes[hash]; collides {
+			return fmt.Errorf("Hash conflict detected between the following files:\n    [%8x] %s\n    [%8x] %s", hash, orig, hash, imginfo.Path)
+		}
+		hashes[hash] = imginfo.Path
+		entry := Entry{
+			TexPath: hash,
+			Coords:  imginfo.Coords,
+		}
+		if _, err := output.Write(entry.Bytes()); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-// addImageAt adds all pixels of `src` to `dst`, starting from pixel at (`x`,`y`).
+func getImageSizes(images []imageInfo) []image.Point {
+	points := make([]image.Point, len(images))
+	for i, imginfo := range images {
+		points[i] = imginfo.Image.Bounds().Size()
+	}
+	return points
+}
+
+// writeImageAt adds all pixels of `src` to `dst`, starting from pixel at (`x`,`y`).
 // It returns an error if the whole source image couldn't be added to the target.
-func addImageAt(dst *image.RGBA, src image.Image, x, y int) error {
+func writeImageAt(dst *image.RGBA, src image.Image, x, y int) error {
 	srcsize := src.Bounds().Size()
 	dstsize := dst.Bounds().Size()
 	if srcsize.X > dstsize.X-x || srcsize.Y > dstsize.Y-y {


### PR DESCRIPTION
(See #12)
Texpacker now works hopefully well. I tried sticking to the rest of the tools' style as much as possible, so it should be pretty familiar to review.

### Usage
```
$ ./texpacker -h
Usage: ./texpacker [flags] <file1> [<file2> ...]
  -noheader
    	Don't write header, output raw PNG
  -o string
    	Output file (- for STDOUT) (default "-")
  -strip string
    	Prefix to strip from file paths for hashing (default <cwd>)

Supported input formats:
    JPEG
    GIF
    PNG
```
Basically it takes input textures as positional arguments and spits out a binary file with the format `[header | PNG image]`. It can be told to output just the PNG for debugging purposes.
The `-strip` flag is used to make the tool usable from any directory: the hashed paths will be relative to the path given to `-strip`.

The packing algorithm is currently maxrects and uses  `"github.com/adinfinit/texpack/maxrect"` which is MIT-licensed.

### Header format
The header looks like this:
```
ParentTexture Hashed Path [4B]
Entry Count               [4B]
Entry0                    [12B]
...

where Entry is:
Hashed Path [4B]
StartX      [2B]
StartY      [2B]
SizeX       [2B]
SizeY       [2B]
```

---

Forgot anything?